### PR TITLE
Correct the ROC AUC computations and add relevant tests.

### DIFF
--- a/src/metrics/test.rs
+++ b/src/metrics/test.rs
@@ -3,6 +3,27 @@
 #[cfg(test)]
 #[allow(unused_imports)]
 
+mod tests {
+    use metrics::ranking::*;
+    use prelude::*;
+    use super::*;
+
+    #[test]
+    fn roc_auc_test_corner_cases() {
+        let tests = vec![
+            (vec![0.0, 1.0, 0.0], vec![1.0, 2.0, 2.0], 0.75),
+            (vec![0.0, 0.0, 1.0], vec![1.0, 2.0, 2.0], 0.75),
+            (vec![0.0, 0.0, 1.0, 1.0], vec![1.0, 2.0, 2.0, 3.0], 0.875),
+            (vec![0.0, 1.0, 0.0, 1.0], vec![1.0, 2.0, 2.0, 3.0], 0.875),
+            (vec![0.0, 0.0, 1.0, 0.0], vec![2.0, 1.0, 1.0, 0.0], 0.5),
+            (vec![0.0, 0.0, 1.0], vec![2.0, 1.0, 1.0], 0.25),
+        ];
+        for test in tests {
+            assert_eq!(roc_auc_score(&test.0.into(), &test.1.into()), Ok(test.2));
+        }
+    }
+}
+
 mod generated_tests {
     use metrics::ranking::*;
     use prelude::*;


### PR DESCRIPTION
The old ROC AUC computations were wrong (at least) in cases of duplicate `y_hat` values. I added a test demonstrating said issue and fixed the computations. 

The table below summarizes the resulting AUCs for each test. Tests 0,1 and tests 2,3 differ only in data-point order, so they should obviously return the same AUCs. I checked the correctness of the new values on paper.

EDIT: also checked using Python's `sklearn.metrics.roc_auc_score`

| test | old AUC  | new AUC |
| -- | ------------- | ------------- |
| 0 | `Ok(1)` | `Ok(0.75)` |
| 1 | `Ok(0.25)` | `Ok(0.75)` |
| 2 | `Ok(0.625)` | `Ok(0.875)` |
| 3 | `Ok(1)` | `Ok(0.875)` |
| 4 | `Ok(0.16666666)` | `Ok(0.5)` |
| 5 | `Ok(NaN)` | `Ok(0.25)` |