### PR TITLE
Use cc instead of gcc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0"
 serde_derive = "1.0"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [dev-dependencies]
 bincode = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,10 @@
 
 // Bring in a dependency on an externally maintained `gcc` package which manages
 // invoking the C compiler.
-extern crate gcc;
-
+extern crate cc;
 
 fn main() {
-    gcc::Config::new()
+    cc::Build::new()
         .cpp(true) // Switch to C++ library compilation.
         .file("dependencies/libsvm/svm.cpp")
         .compile("libsvm.a");


### PR DESCRIPTION
crate gcc will be deprecated, we should use crate cc instead