### PR TITLE
Fix crash on no feature indices

### DIFF
--- a/src/trees/decision_tree.rs
+++ b/src/trees/decision_tree.rs
@@ -315,9 +315,12 @@ impl<'a> SupervisedModel<&'a Array> for DecisionTree {
         try!(check_valid_labels(y));
 
         self.feature_types = DecisionTree::analyze_features(X);
-
+        let nc_feature_indices = self.get_nonconstant_feature_indices();
+        if nc_feature_indices.is_empty() {
+            return Err("No feature was found");
+        }
         let mut feature_values = FeatureValues::with_capacity(X.rows());
-        let mut feature_indices = FeatureIndices::new(self.get_nonconstant_feature_indices());
+        let mut feature_indices = FeatureIndices::new(nc_feature_indices);
         let mut candidate_features = Vec::with_capacity(self.max_features);
 
         self.root = Some(self.build_tree(


### PR DESCRIPTION
If no feature indices are detected, clasifier will panic

```
   9:     0x56419f61951b - <core::option::Option<T>>::unwrap::hd8b8ff2812a12642
                               at /checkout/src/libcore/macros.rs:20
  10:     0x56419f61206a - rustlearn::trees::decision_tree::FeatureIndices::new::h713ea4d48acd865b
                               at /home/rico/.cargo/git/checkouts/rustlearn-1ee86889f45d433e/2ef4de2/src/trees/decision_tree.rs:58
  11:     0x56419f613345 - <rustlearn::trees::decision_tree::DecisionTree as rustlearn::traits::SupervisedModel<&'a rustlearn::array::dense::Array>>::fit::hcc2df1c85dd330cc
                               at /home/rico/.cargo/git/checkouts/rustlearn-1ee86889f45d433e/2ef4de2/src/trees/decision_tree.rs:323
  12:     0x56419f603adf - <rustlearn::ensemble::random_forest::RandomForest as rustlearn::traits::SupervisedModel<&'a rustlearn::array::dense::Array>>::fit::hba6d79b944d21aa4
                               at /home/rico/.cargo/git/checkouts/rustlearn-1ee86889f45d433e/2ef4de2/src/ensemble/random_forest.rs:119

```