### PR TITLE
fixed dorothea example to compile as test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,12 @@ cc = "1.0"
 [dev-dependencies]
 bincode = "1.0"
 csv = "0.14"
-hyper = "0.7.0"
 serde_json = "1.0"
 time = "0.1"
+
+[dev-dependencies.reqwest]
+version = "0.11.3"
+features = ["blocking"]
 
 [features]
 all_tests = []

--- a/examples/dorothea.rs
+++ b/examples/dorothea.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::fs::File;
 
-extern crate hyper;
+extern crate reqwest;
 
 extern crate rustlearn;
 
@@ -21,21 +21,9 @@ use rustlearn::trees::decision_tree;
 use rustlearn::ensemble::random_forest;
 use rustlearn::metrics;
 
-use hyper::client::Client;
-
-
-fn download_data(url: &str) -> Result<String, hyper::error::Error> {
-
-    let client = Client::new();
-
-    let mut output = String::new();
-
-    let mut response = try!(client.get(url).send());
-    try!(response.read_to_string(&mut output));
-
-    Ok(output)
+fn download_data(url: &str) -> reqwest::Result<String> {
+    reqwest::blocking::get(url)?.text()
 }
-
 
 fn get_raw_data(url: &str, filename: &str) -> String {
 


### PR DESCRIPTION
Replaced `hyper` with `reqwest` in the `dev-dependencies` to get `examples/dorothea.rs` to compile. Currently still failing one test: I don't know why.